### PR TITLE
Add support for transitionName as an object

### DIFF
--- a/src/CSSTransitionGroupChild.js
+++ b/src/CSSTransitionGroupChild.js
@@ -21,8 +21,8 @@ const TICK = 17;
 export class CSSTransitionGroupChild extends Component {
 	transition(animationType, finishCallback) {
 		let node = getComponentBase(this),
-			className = this.props.name + '-' + animationType,
-			activeClassName = className + '-active';
+			className = this.props.name[animationType] || this.props.name + '-' + animationType,
+			activeClassName = this.props.name[animationType + 'Active'] || className + '-active';
 
 		if (this.endListener) {
 			this.endListener();


### PR DESCRIPTION
Using the same code Facebook uses to handle this:
https://github.com/facebook/react/blob/v15.4.2/src/addons/transitions/ReactCSSTransitionGroupChild.js#L66-L67

I didn't update any tests because it didn't seem like there'd be a simple way to test just this case without changing a bunch of stuff, so I wanted to get your thoughts first.