### PR TITLE
Filter unrenderable children

### DIFF
--- a/src/CSSTransitionGroup.js
+++ b/src/CSSTransitionGroup.js
@@ -12,7 +12,7 @@
 
 
 import { h, cloneElement, Component } from 'preact';
-import { getKey, filterNullChildren } from './util';
+import { getKey, filterUnrenderableChildren } from './util';
 import { mergeChildMappings, isShownInChildren, isShownInChildrenByKey, inChildren, inChildrenByKey } from './TransitionChildMapping';
 import { CSSTransitionGroupChild } from './CSSTransitionGroupChild';
 
@@ -42,10 +42,10 @@ export class CSSTransitionGroup extends Component {
 	}
 
 	componentWillReceiveProps({ children, exclusive, showProp }) {
-		let nextChildMapping = filterNullChildren(children || []).slice();
+		let nextChildMapping = filterUnrenderableChildren(children || []).slice();
 
 		// last props children if exclusive
-		let prevChildMapping = filterNullChildren(exclusive ? this.props.children : this.state.children);
+		let prevChildMapping = filterUnrenderableChildren(exclusive ? this.props.children : this.state.children);
 
 		let newChildren = mergeChildMappings(
 			prevChildMapping,
@@ -118,7 +118,7 @@ export class CSSTransitionGroup extends Component {
 
 	_handleDoneEntering(key) {
 		delete this.currentlyTransitioningKeys[key];
-		let currentChildMapping = filterNullChildren(this.props.children),
+		let currentChildMapping = filterUnrenderableChildren(this.props.children),
 			showProp = this.props.showProp;
 		if (!currentChildMapping || (
 			!showProp && !inChildrenByKey(currentChildMapping, key)
@@ -157,7 +157,7 @@ export class CSSTransitionGroup extends Component {
 	_handleDoneLeaving(key) {
 		delete this.currentlyTransitioningKeys[key];
 		let showProp = this.props.showProp,
-			currentChildMapping = filterNullChildren(this.props.children);
+			currentChildMapping = filterUnrenderableChildren(this.props.children);
 		if (showProp && currentChildMapping &&
 			isShownInChildrenByKey(currentChildMapping, key, showProp)) {
 			this.performEnter(key);
@@ -202,7 +202,7 @@ export class CSSTransitionGroup extends Component {
 	render({ component:Component, transitionName, transitionEnter, transitionLeave, transitionEnterTimeout, transitionLeaveTimeout, children:c, ...props }, { children }) {
 		return (
 			<Component {...props}>
-				{ filterNullChildren(children).map(this.renderChild) }
+				{ filterUnrenderableChildren(children).map(this.renderChild) }
 			</Component>
 		);
 	}

--- a/src/util.js
+++ b/src/util.js
@@ -10,6 +10,6 @@ export function onlyChild(children) {
 	return children && children[0];
 }
 
-export function filterNullChildren(children) {
-	return children && children.filter(i => i !== null);
+export function filterUnrenderableChildren(children) {
+	return children && children.filter(i => i !== null && i !== undefined && typeof i !== 'boolean');
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -138,6 +138,9 @@ class NullChildren extends Component {
 			<div className='root'>
 				<CSSTransitionGroup transitionName="example">
 					{null}
+					{false}
+					{true}
+					{undefined}
 
 					{ items.map( ({displayed, item}, i) => (
 						displayed ? <Todo key={item} onClick={this.toggleDisplay.bind(this, i)}>


### PR DESCRIPTION
In the current version only `null` is removed from children, but in order to keep [compatibility with React](https://facebook.github.io/react/docs/jsx-in-depth.html#booleans-null-and-undefined-are-ignored), `undefined`, `true` and `false` should also be removed.