### PR TITLE
Use requestAnimationFrame to avoid laggy animation on poor performances devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "mocha": "^2.4.5",
     "npm-run-all": "^2.3.0",
     "phantomjs-prebuilt": "^2.1.5",
-    "preact": "^8.1.0",
+    "preact": "^8.2.7",
     "pretty-bytes-cli": "^1.0.0",
     "rollup": "^0.34.1",
     "rollup-plugin-babel": "^2.4.0",

--- a/src/CSSTransitionGroupChild.js
+++ b/src/CSSTransitionGroupChild.js
@@ -18,6 +18,11 @@ import { addEndEventListener, removeEndEventListener } from './TransitionEvents'
 
 export class CSSTransitionGroupChild extends Component {
 	transition(animationType, finishCallback, timeout) {
+
+		if (!timeout) {
+			this.raiseTimeoutConsoleError(animationType);
+		}
+
 		let node = getComponentBase(this);
 
 		let className = this.props.name[animationType] || this.props.name + '-' + animationType;
@@ -55,6 +60,11 @@ export class CSSTransitionGroupChild extends Component {
 
 		// Need to do this to actually trigger a transition.
 		this.queueClass(activeClassName);
+	}
+
+	raiseTimeoutConsoleError(type) {
+		const timeoutType = type === 'enter' ?  'transitionEnterTimeout' : 'transitionLeaveTimeout';
+		console.error(`${timeoutType} should be specified`);
 	}
 
 	queueClass(className) {

--- a/src/CSSTransitionGroupChild.js
+++ b/src/CSSTransitionGroupChild.js
@@ -12,11 +12,9 @@
 
 
 import { h, Component } from 'preact';
-import { getComponentBase, onlyChild } from './util';
+import { getComponentBase, onlyChild, requestAnimationFrame } from './util';
 import { addClass, removeClass } from './CSSCore';
 import { addEndEventListener, removeEndEventListener } from './TransitionEvents';
-
-const TICK = 17;
 
 export class CSSTransitionGroupChild extends Component {
 	transition(animationType, finishCallback, timeout) {
@@ -62,16 +60,15 @@ export class CSSTransitionGroupChild extends Component {
 	queueClass(className) {
 		this.classNameQueue.push(className);
 
-		if (!this.timeout) {
-			this.timeout = setTimeout(this.flushClassNameQueue, TICK);
+		if (!this.rafHandle) {
+			this.rafHandle = requestAnimationFrame(this.flushClassNameQueue);
 		}
 	}
 
 	stop() {
-		if (this.timeout) {
-			clearTimeout(this.timeout);
+		if (this.rafHandle) {
 			this.classNameQueue.length = 0;
-			this.timeout = null;
+			this.rafHandle = null;
 		}
 		if (this.endListener) {
 			this.endListener();
@@ -83,7 +80,7 @@ export class CSSTransitionGroupChild extends Component {
 			addClass(getComponentBase(this), this.classNameQueue.join(' '));
 		}
 		this.classNameQueue.length = 0;
-		this.timeout = null;
+		this.rafHandle = null;
 	};
 
 	componentWillMount() {
@@ -92,9 +89,8 @@ export class CSSTransitionGroupChild extends Component {
 	}
 
 	componentWillUnmount() {
-		if (this.timeout) {
-			clearTimeout(this.timeout);
-		}
+		this.classNameQueue.length = 0;
+		this.rafHandle = null;
 		this.transitionTimeouts.forEach((timeout) => {
 			clearTimeout(timeout);
 		});

--- a/src/util.js
+++ b/src/util.js
@@ -13,3 +13,32 @@ export function onlyChild(children) {
 export function filterNullChildren(children) {
 	return children && children.filter(i => i !== null);
 }
+
+export const requestAnimationFrame = (() => {
+	let raf;
+
+	if (typeof window !== 'undefined') {
+		raf = window.requestAnimationFrame;
+		const prefixes = ['ms', 'moz', 'webkit', 'o'];
+		for (let i = 0; i < prefixes.length; i++) {
+			if (raf) break;
+			raf = window[`${prefixes[i]}RequestAnimationFrame}`];
+		}
+	}
+
+	if (!raf) {
+		let timeLast = 0;
+		raf = (callback) => {
+			const timeCurrent = new Date().getTime();
+
+			/* Dynamically set the delay on a per-tick basis to more closely match 60fps. */
+			/* Technique by Erik Moller. MIT license: https://gist.github.com/paulirish/1579671. */
+			const timeDelta = Math.max(0, 16 - (timeCurrent - timeLast));
+			timeLast = timeCurrent + timeDelta;
+
+			return setTimeout(() => { callback(timeCurrent + timeDelta); }, timeDelta);
+		};
+	}
+
+	return raf;
+})();

--- a/src/util.js
+++ b/src/util.js
@@ -14,31 +14,11 @@ export function filterNullChildren(children) {
 	return children && children.filter(i => i !== null);
 }
 
-export const requestAnimationFrame = (() => {
-	let raf;
-
-	if (typeof window !== 'undefined') {
-		raf = window.requestAnimationFrame;
-		const prefixes = ['ms', 'moz', 'webkit', 'o'];
-		for (let i = 0; i < prefixes.length; i++) {
-			if (raf) break;
-			raf = window[`${prefixes[i]}RequestAnimationFrame}`];
-		}
+export const requestAnimationFrame = (callback) => {
+	if (typeof window !== 'undefined' && window.requestAnimationFrame) {
+		window.requestAnimationFrame(callback);
 	}
-
-	if (!raf) {
-		let timeLast = 0;
-		raf = (callback) => {
-			const timeCurrent = new Date().getTime();
-
-			/* Dynamically set the delay on a per-tick basis to more closely match 60fps. */
-			/* Technique by Erik Moller. MIT license: https://gist.github.com/paulirish/1579671. */
-			const timeDelta = Math.max(0, 16 - (timeCurrent - timeLast));
-			timeLast = timeCurrent + timeDelta;
-
-			return setTimeout(() => { callback(timeCurrent + timeDelta); }, timeDelta);
-		};
+	else {
+		setTimeout(callback, 17);
 	}
-
-	return raf;
-})();
+};

--- a/tests/index.js
+++ b/tests/index.js
@@ -3,7 +3,7 @@ import CSSTransitionGroup from 'src';
 import { endEvents } from 'src/TransitionEvents';
 import './style.css';
 
-/* global describe,expect,it */
+/* global describe,expect,it,sinon,assert */
 
 class Todo extends Component {
 	defaultProps = {
@@ -71,7 +71,7 @@ class TodoListWithTimeout extends Component {
 	render(_, { items }) {
 		return (
 			<div>
-				<CSSTransitionGroup transitionName="example" transitionEnterTimeout={500} transitionLeaveTimeout={200}>
+				<CSSTransitionGroup transitionName="example" transitionEnterTimeout={1000} transitionLeaveTimeout={1000}>
 					{ items.map( (item, i) => (
 						<Todo key={item} onClick={this.handleRemove.bind(this, i)}>
 							{item}
@@ -103,7 +103,7 @@ class SVGList extends Component {
 	render(_, { items }) {
 		return (
 			<svg>
-				<CSSTransitionGroup transitionName="example" component="g">
+				<CSSTransitionGroup transitionName="example" transitionEnterTimeout={1000} transitionLeaveTimeout={1000} component="g">
 					{ items.map( (item, i) => (
 						<text key={item} className="item">
 							{item}
@@ -136,7 +136,7 @@ class NullChildren extends Component {
 	render(_, { items }) {
 		return (
 			<div className='root'>
-				<CSSTransitionGroup transitionName="example">
+				<CSSTransitionGroup transitionName="example" transitionEnterTimeout={1000} transitionLeaveTimeout={1000}>
 					{null}
 
 					{ items.map( ({displayed, item}, i) => (
@@ -153,7 +153,7 @@ class NullChildren extends Component {
 const Nothing = () => null;
 
 
-describe('CSSTransitionGroup', () => {
+describe('CSSTransitionGroup without timeout', () => {
 	let container = document.createElement('div'),
 		list, root;
 	document.body.appendChild(container);
@@ -163,58 +163,39 @@ describe('CSSTransitionGroup', () => {
 	beforeEach( () => {
 		root = render(<div><Nothing /></div>, container, root);
 		root = render(<div><TodoList ref={c => list=c} /></div>, container, root);
+		sinon.spy(console, 'error');
 	});
 
 	afterEach( () => {
 		list = null;
+		console.error.restore();
 	});
 
 	it('create works', () => {
 		expect($('.item')).to.have.length(4);
 	});
 
-	it('transitionLeave works', done => {
-		// this.timeout(5999);
+	it('transitionLeave raises console error', done => {
 		list.handleRemove(0);
-
-		// make sure -leave class was added
 		setTimeout( () => {
-			expect($('.item')).to.have.length(4);
-
-			expect($('.item')[0].className).to.contain('example-leave');
-			expect($('.item')[0].className).to.contain('example-leave-active');
-		}, 100);
-
-		// then make sure it's gone
-		setTimeout( () => {
-			expect($('.item')).to.have.length(3);
+			assert(console.error.calledOnce);
+			expect(console.error.getCall(0).args[0]).to.equal('transitionLeaveTimeout should be specified');
 			done();
-		}, 1400);
+		}, 100);
 	});
 
-	it('transitionEnter works', done => {
-		// this.timeout(5999);
+	it('transitionEnter raises console error', done => {
 		list.handleAdd(Date.now());
 
 		setTimeout( () => {
-			expect($('.item')).to.have.length(5);
-
-			expect($('.item')[4].className).to.contain('example-enter');
-			expect($('.item')[4].className).to.contain('example-enter-active');
-		}, 500);
-
-		setTimeout( () => {
-			expect($('.item')).to.have.length(5);
-
-			expect($('.item')[4].className).not.to.contain('example-enter');
-			expect($('.item')[4].className).not.to.contain('example-enter-active');
-
+			assert(console.error.calledOnce);
+			expect(console.error.getCall(0).args[0]).to.equal('transitionEnterTimeout should be specified');
 			done();
-		}, 1400);
+		}, 100);
 	});
 });
 
-describe('CSSTransitionGroup: timeout', () => {
+describe('CSSTransitionGroup with timeout', () => {
 	let container = document.createElement('div'),
 		list, root;
 	document.body.appendChild(container);
@@ -250,7 +231,7 @@ describe('CSSTransitionGroup: timeout', () => {
 		setTimeout( () => {
 			expect($('.item')).to.have.length(3);
 			done();
-		}, 300);
+		}, 1400);
 	});
 
 	it('transitionEnter works with the transitionEnterTimeout', done => {
@@ -262,7 +243,7 @@ describe('CSSTransitionGroup: timeout', () => {
 
 			expect($('.item')[4].className).to.contain('example-enter');
 			expect($('.item')[4].className).to.contain('example-enter-active');
-		}, 300);
+		}, 100);
 
 		setTimeout( () => {
 			expect($('.item')).to.have.length(5);
@@ -271,7 +252,7 @@ describe('CSSTransitionGroup: timeout', () => {
 			expect($('.item')[4].className).not.to.contain('example-enter-active');
 
 			done();
-		}, 600);
+		}, 1400);
 	});
 });
 
@@ -319,7 +300,7 @@ describe('CSSTransitionGroup: SVG', () => {
 
 			expect($('.item')[4].classList.contains('example-enter'));
 			expect($('.item')[4].classList.contains('example-enter-active'));
-		}, 500);
+		}, 100);
 
 		setTimeout( () => {
 			expect($('.item')).to.have.length(5);
@@ -379,7 +360,7 @@ describe('CSSTransitionGroup: NullChildren', () => {
 			expect($('.item')).to.have.length(4);
 			expect($('.item')[2].className).to.contain('example-enter');
 			expect($('.item')[2].className).to.contain('example-enter-active');
-		}, 500);
+		}, 100);
 
 		setTimeout( () => {
 			expect($('.item')).to.have.length(4);


### PR DESCRIPTION
 - On poor performances devices, we've experienced some lag when the animation starts.
This was mainly due to the `setTimeout(this.flushClassNameQueue, TICK)` queuing the final `addClass`.   Switching to `requestAnimationFrame` performs better than the `setTimeout` (delayed as a macrotask). `requestAnimationFrame` was actually the [original implementation](https://github.com/reactjs/react-transition-group/blob/v1-stable/src/CSSTransitionGroupChild.js#L122)   

- A `console.error` is also raised when timeouts are not specified in the js api.

- Unit test have been fixed and updated consequent to these changes 